### PR TITLE
Remove disable MiMa plugin

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -30,7 +30,6 @@ val betterMonadicForV = "0.3.1"
 // Projects
 lazy val `http4s-session` = project
   .in(file("."))
-  .disablePlugins(MimaPlugin)
   .enablePlugins(NoPublishPlugin)
   .aggregate(core, examples)
 


### PR DESCRIPTION
Disabling MiMa disables the CI release plugin. `NoPublishPlugin` already does the right things.